### PR TITLE
fix: race condition when running w/o pty, v1.1.6.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ovh-ttyrec (1.1.6.5) master; urgency=medium
+
+  * fix: race condition when running w/o pty
+
+ -- Stéphane Lesimple (deb packages) <stephane.lesimple@corp.ovh.com>  Thu, 04 Sep 2020 16:49:22 +0200
+
 ovh-ttyrec (1.1.6.4) master; urgency=medium
 
   * fix: -k was not working correctly when used without -t


### PR DESCRIPTION
When running in no-pty mode (pipes), we would exit too early
when getting EOF from the subchild's stderr or stdout, instead
of waiting for both to be closed.

Bump to v1.1.6.5