### PR TITLE
fix: don't check errno if read() returned >= 0

### DIFF
--- a/ttyrec.c
+++ b/ttyrec.c
@@ -1412,11 +1412,11 @@ void dooutput(void)
                     else
                     {
                         printdbg2("[stderr:err=%d,%s]", cc, strerror(errno));
-                    }
-                    if (errno != EINTR)
-                    {
-                        stderr_pipe_opened = 0;
-                        close(stderr_pipe[0]);
+                        if (errno != EINTR)
+                        {
+                            stderr_pipe_opened = 0;
+                            close(stderr_pipe[0]);
+                        }
                     }
                 }
                 if (current_fd == stdout_pipe[0])
@@ -1427,11 +1427,11 @@ void dooutput(void)
                     else
                     {
                         printdbg2("[stdout:err=%d,%s]", cc, strerror(errno));
-                    }
-                    if (errno != EINTR)
-                    {
-                        stdout_pipe_opened = 0;
-                        close(stdout_pipe[0]);
+                        if (errno != EINTR)
+                        {
+                            stdout_pipe_opened = 0;
+                            close(stdout_pipe[0]);
+                        }
                     }
                 }
                 if ((stderr_pipe_opened == 0) && (stdout_pipe_opened == 0))


### PR DESCRIPTION
in code introduced by previous commit ec0733df17b717dee8dd48220898ab7e418bef3b,
don't take any implementation-dependent risk if errno is not reset to 0 at
every read() call