### PR TITLE
Stuff next three nibbles of tv_sec into top of tv_nsec to fix y2038

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It should work under any POSIX OS that support either `openpty()` or the `grantp
 - Supports a no-tty mode, relying on pipes instead of pseudottys, while still recording stdout/stderr
 - Automatically detects whether to use pseudottys or pipes, also overridable from command-line
 - Supports reporting the number of bytes that were output to the terminal on session exit
+- Format extended to support dates up to 0xFFFFFFFFFFF
 
 ## compilation
 


### PR DESCRIPTION
The domain of the usec field is [0, 999999] which is [0, 0x000F423F], which leaves us the top three nibbles.
Thus, change the header format from
```
SSSSSSSS
UUUUUUUU
LLLLLLLL
sec = 0xSSSSSSSS
usec = 0xUUUUUUUU
len = LLLLLLLL
```
to
```
SSSSSSSS
sssUUUUU
LLLLLLLL
sec = 0xsssSSSSSSSS
usec = 0x000UUUUU
len = LLLLLLLL
```
this is fully-equivalent until y2038, and introduces a small-but-constant "error" to parsers that don't understand this in files recorded after y2038.

I provide samples of files recorded in 2050, 2100, 2150:
```
$ for f in *.ttyrec; do echo $f; od -txzZ -N32 $f; done
2050.ttyrec
0000000 969b2045 000d873a 0000007f 313f5b1b  >E ..:........[?1<
0000020 1b3d1b68 30323f5b 1b683430 6e3b305d  >h.=.[?2004h.]0;n<
0000040
2100.ttyrec
0000000 f4a7017f 0003e797 0000007f 313f5b1b  >.............[?1<
0000020 1b3d1b68 30323f5b 1b683430 6e3b305d  >h.=.[?2004h.]0;n<
0000040
2150.ttyrec
0000000 52b2e2d6 0016b69c 0000007f 313f5b1b  >...R.........[?1<
0000020 1b3d1b68 30323f5b 1b683430 6e3b305d  >h.=.[?2004h.]0;n<
0000040
```
[2050.ttyrec.gz](https://github.com/user-attachments/files/18547399/2050.ttyrec.gz)
[2100.ttyrec.gz](https://github.com/user-attachments/files/18547400/2100.ttyrec.gz)
[2150.ttyrec.gz](https://github.com/user-attachments/files/18547401/2150.ttyrec.gz)

Closes #37
Closes: Debian#1094187